### PR TITLE
Add libyear badge to readme

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,66 @@
+name: Generate Badges
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  get-badges:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: yarn install
+    - id: libyear
+      uses: s0/libyear-node-action@v0.0.1
+    - run: mkdir badges
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear drift'
+        status: ${{ steps.libyear.outputs.drift }} year(s) behind
+        color: 'blue'
+        path: 'badges/drift.svg'
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear pulse'
+        status: ${{ steps.libyear.outputs.pulse }} year(s) behind
+        color: 'blue'
+        path: 'badges/pulse.svg'
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear'
+        status: ${{ steps.libyear.outputs.releases }} release(s) behind
+        color: 'blue'
+        path: 'badges/releases.svg'
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear'
+        status: ${{ steps.libyear.outputs.major }} major release(s) behind
+        color: 'blue'
+        path: 'badges/major.svg'
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear'
+        status: ${{ steps.libyear.outputs.minor }} minor release(s) behind
+        color: 'blue'
+        path: 'badges/minor.svg'
+    - uses: emibcn/badge-action@v1
+      with:
+        label: 'libyear'
+        status: ${{ steps.libyear.outputs.patch }} patch release(s) behind
+        color: 'blue'
+        path: 'badges/patch.svg'
+    - name: Push badges to gh-badges directory
+      uses: s0/git-publish-subdir-action@v2.4.1
+      env:
+        REPO: self
+        BRANCH: gh-badges
+        FOLDER: badges
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SQUASH_HISTORY: true
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `libyear` &middot; ![](https://github.com/jdanil/libyear/workflows/ci/badge.svg) ![](https://github.com/jdanil/libyear/workflows/cron/badge.svg)
+# `libyear` &middot; ![](https://github.com/jdanil/libyear/workflows/ci/badge.svg) ![](https://github.com/jdanil/libyear/workflows/cron/badge.svg) ![](https://raw.githubusercontent.com/jdanil/libyear/gh-badges/drift.svg)
 
 A Node.js implementation of [libyear](https://libyear.com/).
 


### PR DESCRIPTION
Hey @jdanil,

I have to say nice work on this repo, it's been fun to explore and I like your use of TypeScript.

I've just created a GitHub Action that encapculates your library (also licensed under GPL), and allows users to e.g. generate badges in GitHub actions to include in the README.

I thought you may be interested in adding it to your library itself (as another demo for what it can do). This workflow config should work, but there may be some mistakes given i'm unable to test it on this repository itself.

I plan on extending the action later on to add support for viewing the difference in libyear metrics that a pull request will have.

I'm also particularly interested in programmatic usage that you've listed in your TODO. That will open up some nice possibilities for the action.