### PR TITLE
Add correct export in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jdanil/libyear/issues"
   },
   "main": "./src",
-  "exports": "./src",
+  "exports": "./src/libyear.js",
   "bin": "./bin/libyear.js",
   "type": "module",
   "types": "./src",


### PR DESCRIPTION
Hi there,

I wanted to integrate this package as a library using es imports. I had some troubles while importing the libyear.js

> import { libyear } from 'libyear';
> Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/code/node_modules/libyear/src' is not supported resolving ES modules imported from /code/src/index.mjs

> import { libyear } from 'libyear/libyear.js';
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './libyear.js' is not defined by "exports" in /code/node_modules/libyear/package.json imported from /code/src/index.mjs

> import { libyear } from 'libyear/src/libyear.js';
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/libyear.js' is not defined by "exports" in /code/node_modules/libyear/package.json imported from /code/src/index.mjs

With the fix you can import libyear: `import { libyear } from 'libyear';`