### PR TITLE
Remove option includePreRelease that doesn't have any effect

### DIFF
--- a/src/libyear.ts
+++ b/src/libyear.ts
@@ -63,12 +63,7 @@ export const libyear = async (
           const available =
             [latestStableVersion, latestAllVersion]
               .filter((version) => valid(version))
-              .find(
-                (version) =>
-                  compare(currentVersion, version, {
-                    includePrerelease: true,
-                  }) < 0,
-              ) ?? "N/A";
+              .find((version) => compare(currentVersion, version) < 0) ?? "N/A";
 
           return {
             dependency,


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f0a378c863dcea1df6840dd0d1807632c4465473

This also fix the build as with latest available @types/semver, the project doesn't compile anymore.