### PR TITLE
fix: support unknown current version in drift calculation

### DIFF
--- a/src/date.test.ts
+++ b/src/date.test.ts
@@ -32,6 +32,14 @@ await describe("date", async () => {
         expect(calculateDrift(current, latest)).toBeCloseTo(expected, 2);
       });
     }
+
+    await it('should return 0 when the latest is not there', () => {
+      expect(calculateDrift(EPOCH, '')).toEqual(0);
+    })
+
+    await it('should return 0 when the current is not there', () => {
+      expect(calculateDrift('', EPOCH)).toEqual(0);
+    })
   });
 
   await describe("calculatePulse", async () => {

--- a/src/date.ts
+++ b/src/date.ts
@@ -18,9 +18,13 @@ const differenceInDays = (
 export const calculateDrift = (
   currentVersion: string,
   latestVersion: string,
-): number =>
-  differenceInDays(parseISO(latestVersion), parseISO(currentVersion)) /
-  DAYS_IN_YEAR;
+): number => {
+  if (currentVersion === '' || latestVersion === '') {
+    return 0;
+  }
+  return differenceInDays(parseISO(latestVersion), parseISO(currentVersion)) /
+    DAYS_IN_YEAR;
+};
 
 /**
  * Time since latest version release.


### PR DESCRIPTION

# 🐛 Bug Fix

If current version or latest version is an empty string, default to 0 drift


## 🤔 Tell Us What's Going Wrong

When consumming a package that is only on beta version on npm (so `stable` dosn't exist yet), libyear crashes due to unable to parse `''` to date (due to default value being `''` here: https://github.com/jdanil/libyear/blob/master/src/libyear.ts#L62-L65 )

## 💁 Your Solution

When the current or latest version is an empty string, we default to 0 drift
